### PR TITLE
added rego language case

### DIFF
--- a/src/web/vscode/languages/dictionary.ts
+++ b/src/web/vscode/languages/dictionary.ts
@@ -64,6 +64,7 @@ export function loadLanguageSettings(languageId: string): engine.protocols.Langu
       case 'perl':
       case 'powershell':
       case 'r':
+      case 'rego':
       case 'ruby':
       case 'shell':
       case 'shellscript':


### PR DESCRIPTION
I added the `.rego` language case to support the Rego language policy.